### PR TITLE
Loading spinner

### DIFF
--- a/src/client/actions/index.js
+++ b/src/client/actions/index.js
@@ -1,13 +1,5 @@
-export const START_LOADING = 'start_loading';
 export const FETCH_LEARNERS = 'fetch_learners';
 export const DONE_LOADING = 'done_loading';
-
-export function startLoading() {
-  return {
-    type: START_LOADING,
-    loading: true,
-  };
-}
 
 export function fetchLearners(allLearners) {
   return {

--- a/src/client/components/app/index.jsx
+++ b/src/client/components/app/index.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Route, Switch } from 'react-router-dom';
-import TalentNavbar from '../../containers/talentNavbar';
+import TalentNavbar from '../talentNavbar';
 import NotFound from '../notFound';
 import SkillsSearch from '../../containers/skillsSearch';
 import ScrollToTop from '../scrollToTop';

--- a/src/client/components/app/index.jsx
+++ b/src/client/components/app/index.jsx
@@ -18,24 +18,24 @@ export default class App extends Component {
       <div>
         <ErrorBoundary>
           <TalentNavbar />
-            <Loading>
-              <Switch>
-                <Route exact path="/" component={SplashRNG} />
-                <Route exact path="/current" render={props => (
-                  <LearnerGallery type="current" />
-                )} />
-                <Route exact path="/learners" render={props => (
-                  <LearnerGallery type="all" />
-                )} />
-                <Route exact path="/skillsresults/:searchSkill" component={LearnerGallery} />
-                <Route exact path="/skills" component={SkillsSearch} />
-                <Route exact path="/learners/:githubHandle" component={ProfilePage} />
-                <Route exact path="/alumni" render={props => (
-                  <LearnerGallery type="alumni" />
-                )} />
-                <Route component={NotFound} />
-              </Switch>
-            </Loading>
+          <Loading>
+            <Switch>
+              <Route exact path="/" component={SplashRNG} />
+              <Route exact path="/current" render={props => (
+                <LearnerGallery type="current" />
+              )} />
+              <Route exact path="/learners" render={props => (
+                <LearnerGallery type="all" />
+              )} />
+              <Route exact path="/skillsresults/:searchSkill" component={LearnerGallery} />
+              <Route exact path="/skills" component={SkillsSearch} />
+              <Route exact path="/learners/:githubHandle" component={ProfilePage} />
+              <Route exact path="/alumni" render={props => (
+                <LearnerGallery type="alumni" />
+              )} />
+              <Route component={NotFound} />
+            </Switch>
+          </Loading>
           <ScrollToTop />
           <Footer />
         </ErrorBoundary>

--- a/src/client/components/errorBoundary/index.jsx
+++ b/src/client/components/errorBoundary/index.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-// const fs = require('fs');
 
 export default class ErrorBoundary extends Component {
   constructor(props) {
@@ -16,18 +15,13 @@ export default class ErrorBoundary extends Component {
     });
 
     console.error(error, info);
-    // fs.writeFile('errorLogging.txt', error, (err) => {
-    //   if (err) {
-    //     throw error;
-    //   }
-    //
-    //   console.log('Error logged.');
-    // });
   }
 
   render() {
     if (this.state.hasError) {
-      return <h1>Something went wrong.</h1>;
+      return (
+        <img src="https://c1.staticflickr.com/8/7001/6509400855_aaaf915871_b.jpg" />
+      );
     }
 
     return this.props.children;

--- a/src/client/components/talentNavbar/index.jsx
+++ b/src/client/components/talentNavbar/index.jsx
@@ -1,25 +1,8 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { Link } from 'react-router-dom';
 import { Navbar } from 'react-bootstrap';
-import { startLoading, fetchLearners, doneLoading } from '../../actions';
-import axios from 'axios';
 
-class TalentNavbar extends Component {
-
-  componentWillMount() {
-    this.props.startLoading();
-    axios.get('http://localhost:3000/api/learners')
-    .then(response => response.data)
-    .then(data => this.props.fetchLearners(data))
-    .then(() => this.props.doneLoading())
-    .catch(error => {
-      this.props.doneLoading();
-      console.log('Error fetching and parsing data: ', error);
-      throw error;
-    });
-  }
+export default class TalentNavbar extends Component {
 
   render() {
     return (
@@ -57,9 +40,3 @@ class TalentNavbar extends Component {
     );
   }
 }
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ startLoading, fetchLearners, doneLoading, }, dispatch);
-}
-
-export default connect(null, mapDispatchToProps)(TalentNavbar);

--- a/src/client/containers/learnerGallery/index.jsx
+++ b/src/client/containers/learnerGallery/index.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import CollectionPage from '../collection';
-import { bindActionCreators } from 'redux';
 import _ from 'lodash';
 
 class LearnerGallery extends Component {

--- a/src/client/containers/loading/index.jsx
+++ b/src/client/containers/loading/index.jsx
@@ -1,8 +1,23 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { doneLoading } from '../../actions';
+import { bindActionCreators } from 'redux';
+import { fetchLearners, doneLoading } from '../../actions';
+import axios from 'axios';
 
 class Loading extends Component {
+
+  componentDidMount() {
+    axios.get('http://localhost:3000/api/learners')
+    .then(response => response.data)
+    .then(data => this.props.fetchLearners(data))
+    .then(() => this.props.doneLoading())
+    .catch(error => {
+      this.props.doneLoading();
+      console.log('Error fetching and parsing data: ', error);
+      throw error;
+    });
+  }
+
   render() {
     return (
       <div>
@@ -18,4 +33,8 @@ function mapStateToProps({ guild }) {
   return { guild };
 }
 
-export default connect(mapStateToProps)(Loading);
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ fetchLearners, doneLoading, }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Loading);

--- a/src/client/containers/profile/index.jsx
+++ b/src/client/containers/profile/index.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
 import Profile from './profile';
 import Projects from '../../components/projects';
 import List from '../../components/list';

--- a/src/client/containers/talentNavbar/index.jsx
+++ b/src/client/containers/talentNavbar/index.jsx
@@ -58,12 +58,8 @@ class TalentNavbar extends Component {
   }
 }
 
-function mapStateToProps({ guild }) {
-  return { guild };
-}
-
 function mapDispatchToProps(dispatch) {
   return bindActionCreators({ startLoading, fetchLearners, doneLoading, }, dispatch);
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(TalentNavbar);
+export default connect(null, mapDispatchToProps)(TalentNavbar);

--- a/src/client/containers/talentNavbar/index.jsx
+++ b/src/client/containers/talentNavbar/index.jsx
@@ -15,7 +15,9 @@ class TalentNavbar extends Component {
     .then(data => this.props.fetchLearners(data))
     .then(() => this.props.doneLoading())
     .catch(error => {
-      console.log('Error fetching and parsing data', error);
+      this.props.doneLoading();
+      console.log('Error fetching and parsing data: ', error);
+      throw error;
     });
   }
 

--- a/src/client/reducers/reducer-learner.jsx
+++ b/src/client/reducers/reducer-learner.jsx
@@ -15,7 +15,6 @@ export default function(state = [], action) {
       return {
         learners: state.learners,
         loading: action.loading,
-        exists: true,
       };
   }
   return state;

--- a/src/client/reducers/reducer-learner.jsx
+++ b/src/client/reducers/reducer-learner.jsx
@@ -1,4 +1,4 @@
-import { FETCH_LEARNERS, DONE_LOADING, START_LOADING } from '../actions/';
+import { FETCH_LEARNERS, DONE_LOADING } from '../actions/';
 
 export default function(state = { loading: true }, action) {
   switch (action.type) {

--- a/src/client/reducers/reducer-learner.jsx
+++ b/src/client/reducers/reducer-learner.jsx
@@ -1,11 +1,7 @@
 import { FETCH_LEARNERS, DONE_LOADING, START_LOADING } from '../actions/';
 
-export default function(state = [], action) {
+export default function(state = { loading: true }, action) {
   switch (action.type) {
-    case START_LOADING:
-      return {
-        loading: action.loading,
-      };
     case FETCH_LEARNERS:
       return {
         learners: action.payload,


### PR DESCRIPTION
Fixes # .

Overview
I moved the logic of fetching the learners and dispatching doneLoading to the loading container. This is a better place for that logic, rather than in the navbar where it previously was. To get around asynchronous issues (see previous overview) I edited the reducer. I set the default state to be an object with a loading key set to true, and now when loading is mounted it can see right away that it should mount a loading spinner. As a result of this new default state, we no longer need an action to set loading to true, so I removed the startLoading action from the application. Finally, now that talentNavbar is no longer connected to the redux store or aware of the actions, I moved it to the components directory.

Data Model / DB Schema Changes
<N/A if no changes>

Environment / Configuration Changes
<N/A if no changes>

Notes
