### PR TITLE
Refactored redux store, changes throughout app to reflect refactoring

### DIFF
--- a/src/client/actions/index.js
+++ b/src/client/actions/index.js
@@ -1,10 +1,28 @@
 export const FETCH_LEARNERS = 'fetch_learners';
+export const SET_ALUMNI = 'set_alumni';
+export const SET_CURRENT_LEARNERS = 'set_current_learners';
 export const DONE_LOADING = 'done_loading';
 
 export function fetchLearners(allLearners) {
   return {
     type: FETCH_LEARNERS,
     payload: allLearners,
+    loading: true,
+  };
+}
+
+export function setAlumni(filteredLearners) {
+  return {
+    type: SET_ALUMNI,
+    payload: filteredLearners,
+    loading: true,
+  };
+}
+
+export function setCurrentLearners(filteredLearners) {
+  return {
+    type: SET_CURRENT_LEARNERS,
+    payload: filteredLearners,
     loading: true,
   };
 }

--- a/src/client/components/app/index.jsx
+++ b/src/client/components/app/index.jsx
@@ -22,10 +22,10 @@ export default class App extends Component {
             <Switch>
               <Route exact path="/" component={SplashRNG} />
               <Route exact path="/current" render={props => (
-                <LearnerGallery type="current" />
+                <LearnerGallery type="currentLearners" />
               )} />
               <Route exact path="/learners" render={props => (
-                <LearnerGallery type="all" />
+                <LearnerGallery type="allLearners" />
               )} />
               <Route exact path="/skillsresults/:searchSkill" component={LearnerGallery} />
               <Route exact path="/skills" component={SkillsSearch} />

--- a/src/client/containers/learnerGallery/index.jsx
+++ b/src/client/containers/learnerGallery/index.jsx
@@ -18,14 +18,7 @@ class LearnerGallery extends Component {
   }
 
   filterByName () {
-    let learnersToFilterThrough;
-    if (this.props.type) {
-      learnersToFilterThrough = this.determineSubsetOfLearners(this.props.type);
-    } else {
-      let searchSkills = this.props.match.params.searchSkill.replace(/search=/, '').split(',');
-      learnersToFilterThrough = this.filterByMultipleSkills(searchSkills);
-    }
-
+    const learnersToFilterThrough = this.determineSubsetOfLearners();
     if (!this.state.searchBar) {
       return learnersToFilterThrough;
     }
@@ -69,13 +62,12 @@ class LearnerGallery extends Component {
     });
   }
 
-  determineSubsetOfLearners (type) {
-    if (type === 'alumni') {
-      return this.props.guild.alumni;
-    } else if (type === 'current') {
-      return this.props.guild.currentLearners;
-    } else if (type === 'all') {
-      return this.props.guild.allLearners;
+  determineSubsetOfLearners () {
+    if (this.props.type) {
+      return this.props.guild[this.props.type];
+    } else {
+      const searchSkills = this.props.match.params.searchSkill.replace(/search=/, '').split(',');
+      return this.filterByMultipleSkills(searchSkills);
     }
   }
 

--- a/src/client/containers/learnerGallery/index.jsx
+++ b/src/client/containers/learnerGallery/index.jsx
@@ -6,63 +6,55 @@ import _ from 'lodash';
 class LearnerGallery extends Component {
   constructor(props) {
     super(props);
-
-    if (this.props.type) {
-      this.state = {
-        selectedLearners: this.filterByType(this.props.type),
-      };
-    } else {
-      let searchSkill = this.props.match.params.searchSkill.replace(/search=/, '').split(',');
-      this.state = {
-        selectedLearners: this.filterByMultipleSkills(searchSkill),
-      };
-    }
-
+    this.state = {
+      searchBar: '',
+    };
     this.handleChange = this.handleChange.bind(this);
   }
 
   handleChange(event) {
     event.preventDefault();
-    this.setState({ selectedLearners: event.target.value });
+    this.setState({ searchBar: event.target.value });
   }
 
   filterByName () {
-    let filteredLearner;
+    let learnersToFilterThrough;
     if (this.props.type) {
-      filteredLearner = this.filterByType(this.props.type);
+      learnersToFilterThrough = this.determineSubsetOfLearners(this.props.type);
     } else {
-      let searchSkill = this.props.match.params.searchSkill.replace(/search=/, '').split(',');
-      filteredLearner = this.filterByMultipleSkills(searchSkill);
+      let searchSkills = this.props.match.params.searchSkill.replace(/search=/, '').split(',');
+      learnersToFilterThrough = this.filterByMultipleSkills(searchSkills);
     }
-    if (Array.isArray(this.state.selectedLearners)) {
-      return filteredLearner;
+
+    if (!this.state.searchBar) {
+      return learnersToFilterThrough;
     }
-    let searchTerm = this.state.selectedLearners.toLowerCase().split();
-    let learnersBySkill = this.filterByOneSkill(searchTerm);
-    const foundLearners = filteredLearner.filter(learner => {
-      return learner.name.toLowerCase().includes(this.state.selectedLearners.toLowerCase());
+
+    let searchTerm = this.state.searchBar.toLowerCase().split();
+    const foundLearners = learnersToFilterThrough.filter(learner => {
+      return learner.name.toLowerCase().includes(this.state.searchBar.toLowerCase());
     });
     if (foundLearners.length === 0) {
-      return learnersBySkill;
+      return this.filterByOneSkill(searchTerm, learnersToFilterThrough);
     }
 
     return foundLearners;
   }
 
-  filterByOneSkill (skillToSearchBy) {
-    return this.props.guild.learners.filter(learner => {
+  filterByOneSkill (skillToSearchBy, arrayOfLearners) {
+    return arrayOfLearners.filter(learner => {
       const skillKeys = Object.values(learner.skills).map(object => object.skills);
       let lowerCaseSkillKeys = skillKeys.map(key => key.toLowerCase());
       for (let i = 0; i < lowerCaseSkillKeys.length; i++) {
         if (lowerCaseSkillKeys[i].includes(skillToSearchBy)) {
           return learner;
-        }
+        };
       }
     });
   }
 
   filterByMultipleSkills (searchArray) {
-    return this.props.guild.learners.filter(learner => {
+    return this.props.guild.allLearners.filter(learner => {
       const skillKeys = Object.values(learner.skills).map(object => object.skills);
       let lowerCaseSkillKeys = skillKeys.map(key => key.toLowerCase());
       for (let i = 0; i < searchArray.length; i++) {
@@ -77,20 +69,14 @@ class LearnerGallery extends Component {
     });
   }
 
-  filterByType (type) {
-    return this.props.guild.learners.filter(learner => {
-      if (type === 'alumni') {
-        if (learner.alumni === true) {
-          return learner;
-        }
-      } else if (type === 'current') {
-        if (learner.alumni === false) {
-          return learner;
-        }
-      } else if (type === 'all') {
-        return learner;
-      }
-    });
+  determineSubsetOfLearners (type) {
+    if (type === 'alumni') {
+      return this.props.guild.alumni;
+    } else if (type === 'current') {
+      return this.props.guild.currentLearners;
+    } else if (type === 'all') {
+      return this.props.guild.allLearners;
+    }
   }
 
   getProjects(learners) {

--- a/src/client/containers/loading/index.jsx
+++ b/src/client/containers/loading/index.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { fetchLearners, doneLoading } from '../../actions';
+import { fetchLearners, doneLoading, setAlumni, setCurrentLearners } from '../../actions';
 import axios from 'axios';
 
 class Loading extends Component {
@@ -10,11 +10,23 @@ class Loading extends Component {
     axios.get('http://localhost:3000/api/learners')
     .then(response => response.data)
     .then(data => this.props.fetchLearners(data))
+    .then(() => this.props.setAlumni(this.filterByType('alumni')))
+    .then(() => this.props.setCurrentLearners(this.filterByType('current')))
     .then(() => this.props.doneLoading())
     .catch(error => {
       this.props.doneLoading();
       console.log('Error fetching and parsing data: ', error);
       throw error;
+    });
+  }
+
+  filterByType (type) {
+    return this.props.guild.allLearners.filter(learner => {
+      if (type === 'alumni') {
+        return learner.alumni === true;
+      } else if (type === 'current') {
+        return learner.alumni === false;
+      }
     });
   }
 
@@ -34,7 +46,7 @@ function mapStateToProps({ guild }) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ fetchLearners, doneLoading, }, dispatch);
+  return bindActionCreators({ fetchLearners, setAlumni, setCurrentLearners, doneLoading, }, dispatch);
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Loading);

--- a/src/client/containers/profile/index.jsx
+++ b/src/client/containers/profile/index.jsx
@@ -7,7 +7,7 @@ import List from '../../components/list';
 class ProfilePage extends Component {
 
   filterLearner (githubHandle) {
-    return this.props.guild.learners.filter(learner => {
+    return this.props.guild.allLearners.filter(learner => {
       let currentLearner = learner.github_handle === githubHandle;
       return currentLearner;
     });

--- a/src/client/containers/skillsSearch/index.jsx
+++ b/src/client/containers/skillsSearch/index.jsx
@@ -58,7 +58,7 @@ class SkillsSearch extends Component {
 
   grabSkills() {
     const listOfSkills = [];
-    this.props.guild.learners.forEach(learner => {
+    this.props.guild.allLearners.forEach(learner => {
       return learner.skills.forEach(skill => {
         listOfSkills.push(skill.skills);
       });

--- a/src/client/containers/splashRNG/index.jsx
+++ b/src/client/containers/splashRNG/index.jsx
@@ -15,17 +15,22 @@ class SplashRNG extends Component {
     };
   }
 
+  componentDidMount() {
+    this.rngProjects();
+    this.rngLearners();
+  }
+
   rngProjects() {
     let chosenProjects = [];
-    let maxNumber = this.props.guild.learners.length;
+    let maxNumber = this.props.guild.allLearners.length;
     for (let i = 0; i < 8; i++) {
       let rng = Math.floor(Math.random() * maxNumber);
-      if (chosenProjects.includes(this.props.guild.learners[rng].projects[0])) {
+      if (chosenProjects.includes(this.props.guild.allLearners[rng].projects[0])) {
         i--;
         continue;
       }
 
-      chosenProjects.push(this.props.guild.learners[rng].projects[0]);
+      chosenProjects.push(this.props.guild.allLearners[rng].projects[0]);
     }
 
     this.setState({ selectedProjects: chosenProjects });
@@ -33,14 +38,14 @@ class SplashRNG extends Component {
 
   rngLearners() {
     let chosenLearners = [];
-    let maxNumber = this.props.guild.learners.length;
+    let maxNumber = this.props.guild.allLearners.length;
     for (let i = 0; i < 6; i++) {
       let rng = Math.floor(Math.random() * maxNumber);
-      if (chosenLearners.includes(this.props.guild.learners[rng])) {
+      if (chosenLearners.includes(this.props.guild.allLearners[rng])) {
         i--;
         continue;
       }
-      chosenLearners.push(this.props.guild.learners[rng]);
+      chosenLearners.push(this.props.guild.allLearners[rng]);
     }
     this.setState({ selectedLearners: chosenLearners });
   }
@@ -50,11 +55,6 @@ class SplashRNG extends Component {
   }
 
   handleClickLearners() {
-    this.rngLearners();
-  }
-
-  componentDidMount() {
-    this.rngProjects();
     this.rngLearners();
   }
 

--- a/src/client/reducers/reducer-learner.jsx
+++ b/src/client/reducers/reducer-learner.jsx
@@ -1,15 +1,34 @@
-import { FETCH_LEARNERS, DONE_LOADING } from '../actions/';
+import { FETCH_LEARNERS,
+  SET_ALUMNI,
+  SET_CURRENT_LEARNERS,
+  DONE_LOADING,
+} from '../actions/';
 
 export default function(state = { loading: true }, action) {
   switch (action.type) {
     case FETCH_LEARNERS:
       return {
-        learners: action.payload,
+        allLearners: action.payload,
+        loading: action.loading,
+      };
+    case SET_ALUMNI:
+      return {
+        allLearners: state.allLearners,
+        alumni: action.payload,
+        loading: action.loading,
+      };
+    case SET_CURRENT_LEARNERS:
+      return {
+        allLearners: state.allLearners,
+        alumni: state.alumni,
+        currentLearners: action.payload,
         loading: action.loading,
       };
     case DONE_LOADING:
       return {
-        learners: state.learners,
+        allLearners: state.allLearners,
+        alumni: state.alumni,
+        currentLearners: state.currentLearners,
         loading: action.loading,
       };
   }


### PR DESCRIPTION
Fixes # .

Overview
Added two new actions, setAlumni and setCurrentLearners. In the loading container, after the axios get request is finished and fetchLearners is called, these two new actions are called. I've added reducers so that the redux store will now have two new keys, alumni and current; I've changed what was previously the learners key to allLearners. After the loading container has called all three actions, the redux store will have three arrays stored inside: one will allLearners, one with alumni, and one with learners currently at the Guild. Previously, when the redux store just had all learners under the learner key, whenever LearnerGallery was rendered, it had to filter through the learners and return a subset every time. Now, it can just determine which array from the redux store it needs to grab. LearnerGallery will now only have to filter if a user is coming from the advanced search page. Other changes throughout the files are to account for the new allLearners key.

Data Model / DB Schema Changes
<N/A if no changes>

Environment / Configuration Changes
<N/A if no changes>

Notes
