### PR TITLE
Search bar will now reset to blank value when user navigates to new page

### DIFF
--- a/src/client/containers/learnerGallery/index.jsx
+++ b/src/client/containers/learnerGallery/index.jsx
@@ -16,6 +16,12 @@ class LearnerGallery extends Component {
     this.toggleSearch = this.toggleSearch.bind(this);
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.location !== prevProps.location) {
+      this.setState({ searchBar: '' });
+    }
+  }
+
   toggleSearch(event) {
     if (this.props.guild.nameSearch) {
       this.props.searchBySkill();
@@ -118,6 +124,7 @@ class LearnerGallery extends Component {
             placeholder="search..."
             results="0"
             onChange={this.handleChange}
+            value={this.state.searchBar}
           /><br/>
           <label>
             <input


### PR DESCRIPTION
Fixes # .

Overview
Previously, if a user navigated to a new route that rendered the LearnerGallery container, and they were coming from a route that was rendering the LearnerGallery container, react-router would not unmount and mount the container, and thus the state of the container would never reset. With this change, the search bar will now reset to empty when a user navigates to a new page.

Data Model / DB Schema Changes
<N/A if no changes>

Environment / Configuration Changes
<N/A if no changes>

Notes
