### PR TITLE
Gallery page styling

### DIFF
--- a/src/client/components/talentNavbar/index.css
+++ b/src/client/components/talentNavbar/index.css
@@ -145,7 +145,6 @@ input[type=checkbox]:checked + label ~ .talent-list {
   }
 }
 
-<<<<<<< HEAD
 @media only screen and (min-device-width: 768px) and (max-device-width: 1024px) {
   .talent-nav {
     width: 50%;
@@ -178,12 +177,4 @@ input[type=checkbox]:checked + label ~ .talent-list {
   .navbar-title {
     display: none;
   }
-=======
-@media only screen and (min-device-width: 768px) and (max-device-width: 1023px) {
-
-}
-
-@media only screen and (width: 1024px) {
-
->>>>>>> Fixed the navbar for 375 px mobile viewing and normal laptop viewing
 }

--- a/src/client/components/talentNavbar/index.css
+++ b/src/client/components/talentNavbar/index.css
@@ -145,6 +145,7 @@ input[type=checkbox]:checked + label ~ .talent-list {
   }
 }
 
+<<<<<<< HEAD
 @media only screen and (min-device-width: 768px) and (max-device-width: 1024px) {
   .talent-nav {
     width: 50%;
@@ -177,4 +178,12 @@ input[type=checkbox]:checked + label ~ .talent-list {
   .navbar-title {
     display: none;
   }
+=======
+@media only screen and (min-device-width: 768px) and (max-device-width: 1023px) {
+
+}
+
+@media only screen and (width: 1024px) {
+
+>>>>>>> Fixed the navbar for 375 px mobile viewing and normal laptop viewing
 }

--- a/src/client/components/talentNavbar/index.css
+++ b/src/client/components/talentNavbar/index.css
@@ -1,14 +1,14 @@
 .talent-nav {
   background-color: rgb(248, 248, 248);
   width: 10%;
-  position: absolute;
+  position: fixed;
   top: 4rem;
 }
 
 .talent-navbar {
   width: 100%;
   background-color: rgb(248, 248, 248);
-  position: absolute;
+  position: fixed;
   height: 5rem;
   top: 0;
   z-index: 9999;

--- a/src/client/containers/collection/index.jsx
+++ b/src/client/containers/collection/index.jsx
@@ -2,14 +2,12 @@ import React, { Component } from 'react';
 import './index.css';
 import UserGallery from './userGallery';
 import Projects from '../../components/projects';
-import Blurb from '../../components/blurb';
 
 export default class CollectionPage extends Component {
   render() {
     return (
       <div>
       <div className="flex-column-search-page">
-        <Blurb className="" info={this.props.info} />
         <UserGallery data={this.props.data}/>
       </div>
         <h2 className="text-center">Projects</h2>

--- a/src/client/containers/collection/userBadge/index.css
+++ b/src/client/containers/collection/userBadge/index.css
@@ -7,6 +7,24 @@
   height: auto;
 }
 
+@media only screen and (min-device-width: 375px) and (max-device-width: 667px) {
+  .learner-span {
+    width: auto;
+  }
+}
+
+@media only screen and (min-device-width: 667px) and (max-device-width: 767px) {
+
+}
+
+@media only screen and (min-device-width: 768px) and (max-device-width: 1023px) {
+
+}
+
+@media only screen and (min-device-width: 1024px) and (max-device-width: 1440px) {
+
+}
+
 @media only screen and (width: 1920px) {
   .learner-span {
     width: auto;

--- a/src/client/containers/learnerGallery/index.css
+++ b/src/client/containers/learnerGallery/index.css
@@ -1,0 +1,51 @@
+.learner-gallery-container h1 {
+  color: #538C01;
+}
+
+.search-form {
+  display: flex;
+  justify-content: center;
+  border-style: solid;
+  border-color: #ffd800;
+  border-radius: 1px;
+  background-color: #ffd800;
+}
+
+.searchbar {
+  flex: 0.35;
+  font-size: 2rem;
+  outline: none;
+}
+
+.search-by-container input {
+  position: relative;
+  opacity: 0;
+  transform: scale(3);
+  left: 3rem;
+}
+
+.checkbox {
+  background-color: #ffd800;
+  border-style: solid;
+  border-color: #ffd800;
+  border-radius: 1px;
+  color: #538C01;
+  cursor: pointer;
+  font-size: 2rem;
+  padding: 0.3rem;
+  position: relative;
+  top: 0.3rem;
+}
+
+.checkbox-checked {
+  background-color: #ffc700;
+  border-style: solid;
+  border-color: #ffc700;
+  border-radius: 1px;
+  color: #538C01;
+  cursor: pointer;
+  font-size: 2rem;
+  padding: 0.3rem;
+  position: relative;
+  top: 0.3rem;
+}

--- a/src/client/containers/learnerGallery/index.jsx
+++ b/src/client/containers/learnerGallery/index.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import CollectionPage from '../collection';
-import Blurb from '../../components/Blurb';
+import Blurb from '../../components/blurb';
 import _ from 'lodash';
 import { bindActionCreators } from 'redux';
 import { searchBySkill, searchByName } from '../../actions';

--- a/src/client/containers/learnerGallery/index.jsx
+++ b/src/client/containers/learnerGallery/index.jsx
@@ -101,7 +101,7 @@ class LearnerGallery extends Component {
   }
 
   render() {
-    let names = this.determineSubsetOfLearners(this.props.type);
+    let names;
     if (this.props.guild.nameSearch) {
       names = this.filterByName(this.state.searchBar);
     } else {
@@ -118,6 +118,7 @@ class LearnerGallery extends Component {
             results="0"
             onChange={this.handleChange}
             className="searchbar"
+            value={this.state.searchBar}
           />
           <div>
             <label className="search-by-container">

--- a/src/client/containers/learnerGallery/index.jsx
+++ b/src/client/containers/learnerGallery/index.jsx
@@ -1,15 +1,16 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import CollectionPage from '../collection';
+import Blurb from '../../components/Blurb';
 import _ from 'lodash';
 import { bindActionCreators } from 'redux';
 import { searchBySkill, searchByName } from '../../actions';
+import './index.css';
 
 class LearnerGallery extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      learnersByType: this.determineSubsetOfLearners(this.props.type),
       searchBar: '',
     };
     this.handleChange = this.handleChange.bind(this);
@@ -30,16 +31,13 @@ class LearnerGallery extends Component {
   }
 
   filterByName () {
-    const filteredLearner = this.determineSubsetOfLearners(this.props.type);
-
+    const learnersToFilterThrough = this.determineSubsetOfLearners(this.props.type);
     if (!this.state.searchBar) {
-      return filteredLearner;
+      return learnersToFilterThrough;
     }
-    let searchTerm = this.state.selectedLearners.toLowerCase().split();
-    let learnersBySkill = this.filterByOneSkill(searchTerm);
 
     const searchBar = this.state.searchBar.toLowerCase().split(' ')[0];
-    const foundLearners = filteredLearner.filter(learner => {
+    const foundLearners = learnersToFilterThrough.filter(learner => {
       return learner.name.toLowerCase().includes(searchBar);
     });
 
@@ -56,7 +54,7 @@ class LearnerGallery extends Component {
   }
 
   filterByOneSkill(skillToSearchBy) {
-    return this.state.learnersByType.filter(learner => {
+    return this.determineSubsetOfLearners(this.props.type).filter(learner => {
       const skillKeys = Object.values(learner.skills).map(object => object.skills);
       let lowerCaseSkillKeys = skillKeys.map(key => key.toLowerCase());
       for (let i = 0; i < lowerCaseSkillKeys.length; i++) {
@@ -103,7 +101,7 @@ class LearnerGallery extends Component {
   }
 
   render() {
-    let names = this.state.learnersByType;
+    let names = this.determineSubsetOfLearners(this.props.type);
     if (this.props.guild.nameSearch) {
       names = this.filterByName(this.state.searchBar);
     } else {
@@ -111,35 +109,50 @@ class LearnerGallery extends Component {
     }
 
     return (
-      <div>
-        <div>
+      <div className="learner-gallery-container" >
+        <Blurb info={ { name: 'FIND YOUR TALENT', story: '' } } />
+        <div className="search-form">
           <input
             type="text"
             placeholder="search..."
             results="0"
             onChange={this.handleChange}
-          /><br/>
-          <label>
-            <input
-              type='radio'
-              name='searchBy'
-              onChange={this.toggleSearch}
-              checked={this.props.guild.nameSearch}
-            /> Name
-          </label>
-          <label>
-            <input
-              type='radio'
-              name='searchBy'
-              onChange={this.toggleSearch}
-              checked={this.props.guild.skillSearch}
-            /> Skill
-          </label>
+            className="searchbar"
+          />
+          <div>
+            <label className="search-by-container">
+              <input
+                type='radio'
+                name='searchBy'
+                onChange={this.toggleSearch}
+                checked={this.props.guild.nameSearch}
+                className="search-form-radio"
+              />
+              { this.props.guild.nameSearch ? (
+                <span className="checkbox-checked">Name</span>
+              ) : (
+                <span className="checkbox">Name</span>
+              ) }
+            </label>
+            <label className="search-by-container">
+              <input
+                type='radio'
+                name='searchBy'
+                onChange={this.toggleSearch}
+                checked={this.props.guild.skillSearch}
+                className="search-form-radio"
+              />
+              { this.props.guild.skillSearch ? (
+                <span className="checkbox-checked">Skill</span>
+              ) : (
+                <span className="checkbox">Skill</span>
+              ) }
+            </label>
+          </div>
         </div>
 
         <CollectionPage
           data={names}
-          info={ { name: 'ABOUT LEARNERS GUILD', story: 'This is just a sentence.' } }
           projects={this.getProjects(names)}
         />
       </div>

--- a/src/client/containers/profile/profile/index.jsx
+++ b/src/client/containers/profile/profile/index.jsx
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import Blurb from '../../../components/blurb';
 import './index.css';
 
@@ -11,21 +11,11 @@ export default class Profile extends Component {
           <img className="" src="/LearnerImage.png" />
           <Blurb className="" info={this.props.info} />
         </div>
-<<<<<<< HEAD
         <ul className="logo-list">
           <a href={`https://github.com/${this.props.github_handle}`} target="_blank"><li><img className="logo-list-image" src="/Logos/Github-Mark-64px.png" /></li></a>
           <a href={`https://www.linkedin.com/in/${this.props.linkedin_profile}`} target="_blank"><li><img className="logo-list-image" src="/Logos/square-linkedin-512.png" /></li></a>
           <a href={`https://www.twitter.com/${this.props.twitter}`} target="_blank"><li></li><img className="logo-list-image" src="/Logos/Twitter_Logo_Blue.png" /></a>
         </ul>
-=======
-        <div className="row">
-          <div bsSize="large" title="Personal Contact Information" id="dropdown-size-large">
-            <div href={`https://github.com/${this.props.github_handle}`} target="_blank" eventKey="1">Github</div>
-            <div href={`https://www.linkedin.com/in/${this.props.linkedin_profile}`} target="_blank" eventKey="2">Linkedin</div>
-            <div href={`https://www.twitter.com/${this.props.twitter}`} target="_blank" eventKey="3">Twitter</div>
-          </div>
-        </div>
->>>>>>> Fixed the navbar for 375 px mobile viewing and normal laptop viewing
       </div>
     );
   }

--- a/src/client/containers/profile/profile/index.jsx
+++ b/src/client/containers/profile/profile/index.jsx
@@ -11,11 +11,21 @@ export default class Profile extends Component {
           <img className="" src="/LearnerImage.png" />
           <Blurb className="" info={this.props.info} />
         </div>
+<<<<<<< HEAD
         <ul className="logo-list">
           <a href={`https://github.com/${this.props.github_handle}`} target="_blank"><li><img className="logo-list-image" src="/Logos/Github-Mark-64px.png" /></li></a>
           <a href={`https://www.linkedin.com/in/${this.props.linkedin_profile}`} target="_blank"><li><img className="logo-list-image" src="/Logos/square-linkedin-512.png" /></li></a>
           <a href={`https://www.twitter.com/${this.props.twitter}`} target="_blank"><li></li><img className="logo-list-image" src="/Logos/Twitter_Logo_Blue.png" /></a>
         </ul>
+=======
+        <div className="row">
+          <div bsSize="large" title="Personal Contact Information" id="dropdown-size-large">
+            <div href={`https://github.com/${this.props.github_handle}`} target="_blank" eventKey="1">Github</div>
+            <div href={`https://www.linkedin.com/in/${this.props.linkedin_profile}`} target="_blank" eventKey="2">Linkedin</div>
+            <div href={`https://www.twitter.com/${this.props.twitter}`} target="_blank" eventKey="3">Twitter</div>
+          </div>
+        </div>
+>>>>>>> Fixed the navbar for 375 px mobile viewing and normal laptop viewing
       </div>
     );
   }


### PR DESCRIPTION
Fixes # .

Overview
Started the styling for the gallery page. I removed the responsibility of rendering the Blurb component away from the Collection Page and to Learner Gallery to better match the mockups Rachel provided. This pull request also fixes a bug where searching for learners by skills was looking at the local component's state to determine whether to search through alumni, current, or all learners. This was an issue because the state of Learner Gallery was not changing when a user navigated to a new route, so while initially alumni, or current learners would be displayed on the page, the searching based on skills was filtering through the subset of learners from the previous route. For this reason, even though the styling isn't finished, I feel the changes I've made should be merged into master and then everyone can rebase and work off of the version of the app where this bug is fixed.

Data Model / DB Schema Changes
<N/A if no changes>

Environment / Configuration Changes
<N/A if no changes>

Notes
